### PR TITLE
This should fix that Bad Metronome runs twice as fast as it should

### DIFF
--- a/BadMetronome/src/com/jpapps/badmetronome/Metronome.java
+++ b/BadMetronome/src/com/jpapps/badmetronome/Metronome.java
@@ -91,6 +91,7 @@ public class Metronome {
 			public void run() {		
 				while (playing) {
 					int beatLength = (int) Math.round((60.0/bpm)*audioTrack.getSampleRate());
+					beatLength = beatLength * 2;
 					int soundLength = sound.length;
 					if(soundLength > beatLength)
 						soundLength = beatLength; //with higher BPMs, the full sound is too long


### PR DESCRIPTION
One audio sample consists of two bytes, not only one.

BTW: It would be great if Bad Metronome contained a license file, so that I know wether I can reuse the code for my Classical Metronome spike project.

[Metronome.java.zip](https://github.com/pandapaul/BadMetronome/files/1721763/Metronome.java.zip)